### PR TITLE
Add AsyncCommand<T> with strongly typed parameter

### DIFF
--- a/src/Nito.Mvvm.Async/AsyncCommandT.cs
+++ b/src/Nito.Mvvm.Async/AsyncCommandT.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace Nito.Mvvm
+{
+    /// <summary>
+    /// A strongly typed parameterized asynchronous command, which forwards it's implementation to <see cref="AsyncCommand"/>.
+    /// </summary>
+    public sealed class AsyncCommand<T> : AsyncCommandBase, IAsyncCommand<T>, INotifyPropertyChanged
+    {
+        private readonly AsyncCommand _asyncCommand;
+
+        /// <summary>
+        /// Creates a new asynchronous command, with the specified asynchronous delegate as its implementation.
+        /// </summary>
+        /// <param name="executeAsync">The implementation of <see cref="IAsyncCommand{T}.ExecuteAsync(T)"/>.</param>
+        /// <param name="canExecuteChangedFactory">The factory for the implementation of <see cref="ICommand.CanExecuteChanged"/>.</param>
+        public AsyncCommand(Func<T, Task> executeAsync, Func<object, ICanExecuteChanged> canExecuteChangedFactory)
+            : base(canExecuteChangedFactory)
+        {
+            _asyncCommand = new AsyncCommand(async parameter => await executeAsync((T)parameter), canExecuteChangedFactory);
+            _asyncCommand.PropertyChanged += (object sender, PropertyChangedEventArgs e) =>
+            {
+                switch (e.PropertyName)
+                {
+                    case nameof(_asyncCommand.IsExecuting):
+                        PropertyChanged?.Invoke(this, PropertyChangedEventArgsCache.Instance.Get(nameof(IsExecuting)));
+                        break;
+                    case nameof(_asyncCommand.Execution):
+                        PropertyChanged?.Invoke(this, PropertyChangedEventArgsCache.Instance.Get(nameof(Execution)));
+                        break;
+                }
+            };
+            ((ICommand)_asyncCommand).CanExecuteChanged += (object sender, EventArgs e) => OnCanExecuteChanged();
+        }
+
+        /// <summary>
+        /// Creates a new asynchronous command, with the specified asynchronous delegate as its implementation.
+        /// </summary>
+        /// <param name="executeAsync">The implementation of <see cref="IAsyncCommand{T}.ExecuteAsync(T)"/>.</param>
+        public AsyncCommand(Func<T, Task> executeAsync)
+            : this(executeAsync, CanExecuteChangedFactories.DefaultCanExecuteChangedFactory)
+        {
+        }
+
+        /// <summary>
+        /// Raised when any properties on this instance have changed.
+        /// </summary>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// Represents the most recent execution of the asynchronous command. Returns <c>null</c> until the first execution of this command.
+        /// </summary>
+        public NotifyTask Execution => _asyncCommand.Execution;
+
+        /// <summary>
+        /// Whether the asynchronous command is currently executing.
+        /// </summary>
+        public bool IsExecuting => _asyncCommand.IsExecuting;
+
+
+        /// <summary>
+        /// The implementation of <see cref="ICommand.CanExecute(object)"/>. Returns <c>false</c> whenever the async command is in progress.
+        /// </summary>
+        /// <param name="parameter">The parameter for the command.</param>
+        protected override bool CanExecute(object parameter) => ((ICommand)_asyncCommand).CanExecute(parameter);
+
+        /// <summary>
+        /// Executes the command asynchronously.
+        /// </summary>
+        /// <param name="parameter">The parameter for the command.</param>
+        public override Task ExecuteAsync(object parameter)
+        {
+            return ExecuteAsync((T)parameter);
+        }
+
+        /// <summary>
+        /// Executes the command asynchronously.
+        /// </summary>
+        /// <param name="parameter">The parameter for the command.</param>
+        public Task ExecuteAsync(T parameter)
+        {
+            return _asyncCommand.ExecuteAsync(parameter);
+        }
+    }
+}

--- a/src/Nito.Mvvm.Async/IAsyncCommandT.cs
+++ b/src/Nito.Mvvm.Async/IAsyncCommandT.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+
+namespace Nito.Mvvm
+{
+    /// <summary>
+    /// A strongly typed async version of <see cref="IAsyncCommand"/>.
+    /// </summary>
+    public interface IAsyncCommand<T> : IAsyncCommand
+    {
+        /// <summary>
+        /// Executes the asynchronous command.
+        /// </summary>
+        /// <param name="parameter">The parameter for the command.</param>
+        Task ExecuteAsync(T parameter);
+    }
+}

--- a/test/UnitTests/AsyncCommandTUnitTests.cs
+++ b/test/UnitTests/AsyncCommandTUnitTests.cs
@@ -1,0 +1,99 @@
+﻿using Nito.Mvvm;
+using System;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Xunit;
+
+namespace UnitTests
+{
+    public class AsyncCommandTUnitTests
+    {
+        [Fact]
+        public void AfterConstruction_IsNotExecuting()
+        {
+            var command = new AsyncCommand<string>(_ => Task.CompletedTask);
+            Assert.False(command.IsExecuting);
+            Assert.Null(command.Execution);
+            Assert.True(((ICommand)command).CanExecute(""));
+        }
+
+        [Fact]
+        public void AfterSynchronousExecutionComplete_IsNotExecuting()
+        {
+            var command = new AsyncCommand<int>(_ => Task.CompletedTask);
+
+            ((ICommand)command).Execute(0);
+
+            Assert.False(command.IsExecuting);
+            Assert.NotNull(command.Execution);
+            Assert.True(((ICommand)command).CanExecute(0));
+        }
+
+        [Fact]
+        public async Task ExecuteWithWrongParameterType_ThrowsCastException()
+        {
+            var command = new AsyncCommand<bool>(_ => Task.CompletedTask);
+
+            await Assert.ThrowsAsync<InvalidCastException>(() =>
+                command.ExecuteAsync("A STRING")
+            );
+        }
+
+        [Fact]
+        public void StartExecution_IsExecuting()
+        {
+            var signal = new TaskCompletionSource<object>();
+            var command = new AsyncCommand<object>(_ => signal.Task);
+
+            ((ICommand)command).Execute(null);
+
+            Assert.True(command.IsExecuting);
+            Assert.NotNull(command.Execution);
+            Assert.False(((ICommand)command).CanExecute(null));
+
+            signal.SetResult(null);
+        }
+
+        [Fact]
+        public void Execute_DelaysExecutionUntilCommandIsInExecutingState()
+        {
+            bool isExecuting = false;
+            NotifyTask execution = null;
+            bool canExecute = true;
+
+            AsyncCommand<int> command = null;
+            command = new AsyncCommand<int>((intParam) =>
+            {
+                isExecuting = command.IsExecuting;
+                execution = command.Execution;
+                canExecute = ((ICommand)command).CanExecute(intParam);
+                return Task.CompletedTask;
+            });
+
+            ((ICommand)command).Execute(0);
+
+            Assert.True(isExecuting);
+            Assert.NotNull(execution);
+            Assert.False(canExecute);
+        }
+
+        [Fact]
+        public void StartExecution_NotifiesPropertyChanges()
+        {
+            var signal = new TaskCompletionSource<object>();
+            var command = new AsyncCommand<object>(_ => signal.Task);
+            var isExecutingNotification = TestUtils.PropertyNotified(command, n => n.IsExecuting);
+            var executionNotification = TestUtils.PropertyNotified(command, n => n.Execution);
+            var sawCanExecuteChanged = false;
+            ((ICommand)command).CanExecuteChanged += (_, __) => { sawCanExecuteChanged = true; };
+
+            ((ICommand)command).Execute(null);
+
+            Assert.True(isExecutingNotification());
+            Assert.True(executionNotification());
+            Assert.True(sawCanExecuteChanged);
+
+            signal.SetResult(null);
+        }
+    }
+}


### PR DESCRIPTION
### Description

In the WPF MVVM world, it is fairly common for projects to write their
own simple command implementations, sometimes called DelegateCommand,
RelayCommand or simply Command. Since ICommand uses object as the
parameter type, it is also common for developers using CommandParameter
often to implement a generic Command<T> to avoid casting boilerplate.

For the same reason, this adds a strongly typed AsyncCommand<T> that
simply wraps an AsyncCommand, relaying CanExecutedChanged and
PropertyChanged events as well as the Execute call, casting the
parameter.

### Example usage

XAML:
```xaml
<Window x:Class="Example.MainWindow"
        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
        xmlns:local="clr-namespace:Example"
        mc:Ignorable="d"
        Title="MainWindow" Height="450" Width="800">
    <Window.DataContext>
        <local:MainWindowViewModel />
    </Window.DataContext>
    <Grid>
        <Button
            Command="{Binding UpdateLastPickedCommand}"
            CommandParameter="{x:Static local:Fruit.Apple}"
            Content="Update Last Picked" />
    </Grid>
</Window>

```

c#:
```csharp
using Nito.Mvvm;
using System.IO;
using System.Threading.Tasks;

namespace Example
{
    public enum Fruit { Apple }

    public class MainWindowViewModel
    {
        public MainWindowViewModel()
        {
            UpdateLastPickedCommand = new AsyncCommand<Fruit>(UpdateLastPicked);
        }

        public IAsyncCommand<Fruit> UpdateLastPickedCommand { get; }

        private Task UpdateLastPicked(Fruit fruitClicked)
        {
            return File.WriteAllTextAsync("LastFruitPicked.txt", fruitClicked.ToString());
        }
    }
}
```

This basically allows:
```csharp
// Current way
UpdateLastPickedCommand = new AsyncCommand((fruit) => UpdateLastPicked((Fruit)fruit));

// With strongly typed AsyncCommand
UpdateLastPickedCommand = new AsyncCommand<Fruit>(UpdateLastPicked);
```