### PR TITLE
Remove useless awaits that cause application crashes

### DIFF
--- a/src/Nito.Mvvm.Async/AsyncCommand.cs
+++ b/src/Nito.Mvvm.Async/AsyncCommand.cs
@@ -88,7 +88,6 @@ namespace Nito.Mvvm
             await Execution.TaskCompleted;
             OnCanExecuteChanged();
             PropertyChanged?.Invoke(this, PropertyChangedEventArgsCache.Instance.Get("IsExecuting"));
-            await Execution.Task;
         }
 
         /// <summary>

--- a/src/Nito.Mvvm.Async/CancelCommand.cs
+++ b/src/Nito.Mvvm.Async/CancelCommand.cs
@@ -118,14 +118,7 @@ namespace Nito.Mvvm
             {
                 using (StartOperation())
                 {
-                    try
-                    {
-                        await executeAsync(parameter, _context.Token);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        // We cannot use `when (ex.CancellationToken == cancellationToken)` on the catch block because the user delegate may be cancelled by a linked CancellationToken.
-                    }
+                    await executeAsync(parameter, _context.Token);
                 }
             };
         }

--- a/src/Nito.Mvvm.Async/CustomAsyncCommand.cs
+++ b/src/Nito.Mvvm.Async/CustomAsyncCommand.cs
@@ -96,7 +96,6 @@ namespace Nito.Mvvm
             tcs.SetResult(null);
             await Execution.TaskCompleted;
             PropertyChanged?.Invoke(this, PropertyChangedEventArgsCache.Instance.Get("IsExecuting"));
-            await Execution.Task;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #28 

I don't see why `Execution.Task` needs to be awaited again, because `Execution.TaskCompleted` was already awaited.